### PR TITLE
Add ability to specify the source interface(s) of the broadcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,18 @@ Tested on Linux and Windows with P1P. If it works on X1 series let me know.
   - IP address
   - Serial Number
   - Access Code
-- Run bsnotify on the same LAN as your slicer.
+- Run bsnotify on the same LAN as your slicer (the device running Bambu Studio).
 
 
 ```
 python3 bsnotify <printer-ip> <printer-serial-number>
+```
+
+Optional:
+Specify the source address(es) as comma separated values. This will allow for broadcasting on specific network(s) from a server or router (such as a Unifi Dream Machine) that has multiple interfaces.
+
+```
+python3 bsnotify <printer-ip> <printer-serial-number> <local address(es)>
 ```
 
 ## The Details

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ SSDP is the only way.
 
 Thats where bsnotify comes in, it will notify BS of printers outside your LAN.
 
-Tested on Linux and Windows with P1P. If it works on X1 series let me know.
+Tested on Linux and Windows with P1P. 
+Tested on MacOS and Linux with X1C.
 
 ## Requirements
 
@@ -41,4 +42,5 @@ python3 bsnotify <printer-ip> <printer-serial-number> <local address(es)>
   - to 255.255.255.255:2021  - BS responds to this
   - to 239.255.255.250:1990  - BS ignores this
 - BS sends out SEARCH requests but never gets a reply.
+- This script spoofs the multicast response from the printer but on the network that you're using for Bambu Studio. Even if you add the device manually, Bambu Studio still expects this multicast packet.
 

--- a/README.md
+++ b/README.md
@@ -44,3 +44,46 @@ python3 bsnotify <printer-ip> <printer-serial-number> <local address(es)>
 - BS sends out SEARCH requests but never gets a reply.
 - This script spoofs the multicast response from the printer but on the network that you're using for Bambu Studio. Even if you add the device manually, Bambu Studio still expects this multicast packet.
 
+## Optional: Installing as a service on linux 
+Git clone, scp, copy-paste, etc. bsnotify.py to /etc/bsnotify (or whatever filepath you want, but make sure to specify in the service file)
+
+Create a file /etc/systemd/system/bsnotify.service (fill in the values for the command)
+
+```
+[Unit]
+Description=BSNotify Service to enable Bambu Studio across VLANs
+
+[Service]
+Type=simple
+ExecStart=python3 /etc/bsnotify/bsnotify <printer-ip> <printer-serial-number> <local address(es)>
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Run
+```
+systemctl daemon-reload
+systemctl enable bsnotify.service
+systemctl restart bsnotify.service 
+systemctl status bsnotify.service
+```
+
+Example output:
+```
+bsnotify.service - BSNotify Service to enable Bambu Studio across VLANs
+     Loaded: loaded (/etc/systemd/system/bsnotify.service; enabled; vendor preset: enabled)
+     Active: active (running) since Thu 2025-01-02 17:14:04 CST; 11s ago
+   Main PID: 3907202 (python3)
+      Tasks: 3 (limit: 4724)
+     Memory: 8.9M
+        CPU: 164ms
+     CGroup: /system.slice/bsnotify.service
+             └─3907202 python3 /etc/bsnotify/bsnotify 10.2.1.100 XXXXXXXXXX 10.1.1.1,10.3.1.1
+
+Jan 02 17:18:04 Router-1 systemd[1]: Started BSNotify Service to enable Bambu Studio across VLANs.
+Jan 02 17:18:04 Router-1 python3[3907202]: 10.1.1.1 coroutine running...
+Jan 02 17:18:04 Router-1 python3[3907202]: 10.3.1.1 coroutine running...
+Jan 02 17:18:39 Router-1 python3[3907202]: SSDP NOTIFY for printer 3DP-XXX-XXX ( 10.2.1.100 ) sent to 255.255.255.255 2021 from address: 10.1.1.1
+Jan 02 17:18:39 Router-1 python3[3907202]: SSDP NOTIFY for printer 3DP-XXX-XXX ( 10.2.1.100 ) sent to 255.255.255.255 2021 from address: 10.3.1.1
+```

--- a/bsnotify
+++ b/bsnotify
@@ -4,6 +4,10 @@ import argparse
 import asyncio
 import socket
 import types
+import threading
+import time
+import os
+import signal
 
 CFG = types.SimpleNamespace(
     MCAST_ADDR="255.255.255.255",
@@ -45,45 +49,68 @@ def setup():
     parser.add_argument("PRINTER_SN",
                         help="Printer Serial Number",
                         type=str.upper)
+    parser.add_argument("LOCAL_ADDRESSES", help="Comma Separated Address(es) of the local interface to broadcast from" +
+                        "\nUseful for running on a server or router with multiple interfaces and broadcast domains" +
+                        "\nEx:"+
+                        "\n10.1.1.1"+
+                        "\n10.1.1.1,10.2.1.1",
+                        default=None, 
+                        nargs='?')
     args = parser.parse_args()
     CFG.PRINTER_IP = args.PRINTER_IP
     CFG.PRINTER_SN = args.PRINTER_SN
     CFG.PRINTER_NAME = "3DP-{}-{}".format(CFG.PRINTER_SN[0:3],
                                           CFG.PRINTER_SN[-3:])
+    CFG.LOCAL_ADDRESSES = args.LOCAL_ADDRESSES.split(",") if args.LOCAL_ADDRESSES else [None]
     return args
 
 
-async def sendloop(transport):
+async def sendloop(transport, local_addr):
     target = (CFG.MCAST_ADDR, CFG.MCAST_PORT)
 
     msg = notify_msg()
 
     while True:
-        print("SSDP NOTIFY for printer {} ( {} ) sent to {} {}".format(
-            CFG.PRINTER_NAME, CFG.PRINTER_IP, CFG.MCAST_ADDR, CFG.MCAST_PORT))
+        print("SSDP NOTIFY for printer {} ( {} ) sent to {} {} from address: {}".format(
+            CFG.PRINTER_NAME, CFG.PRINTER_IP, CFG.MCAST_ADDR, CFG.MCAST_PORT, local_addr or "default"))
         transport.sendto(msg, target)
         await asyncio.sleep(CFG.NOTIFY_INTERVAL)
 
 
 def main():
-
     args = setup()
 
-    loop = asyncio.get_event_loop()
-    connect = loop.create_datagram_endpoint(asyncio.DatagramProtocol,
-                                            family=socket.AF_INET,
-                                            allow_broadcast=True)
-
-    transport, protocol = loop.run_until_complete(connect)
+    threads = list()
 
     try:
-        asyncio.run(sendloop(transport))
+        for local_address in CFG.LOCAL_ADDRESSES:
+            thread = threading.Thread(target=asyncio.run, args=(coroutine(local_address),))
+            threads.append(thread)
+            thread.start()
+        while True:
+            time.sleep(100)
     except KeyboardInterrupt:
-        pass
+        print("Stopping threads...")
+        os.kill(os.getpid(), signal.SIGTERM)
+
+async def coroutine(local_address=None):
+    # report a message
+    print(f'{local_address or "default"} coroutine running...', flush=True)
+    # get the loop for this thread
+    loop = asyncio.get_running_loop()
+
+    local_addr_tuple = (local_address, None) if local_address else None
+    connect = loop.create_datagram_endpoint(asyncio.DatagramProtocol,
+                                            family=socket.AF_INET,
+                                            allow_broadcast=True,
+                                            local_addr=local_addr_tuple)
+
+    transport, protocol = await connect
+
+    await sendloop(transport, local_address)
 
     transport.close()
     loop.close()
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Not sure if you still maintain this, but I've added some functionality I needed and wanted to contribute it back since this is linked in a couple of places and Bambu still doesn't have direct IP connections working across VLANs (on the X1C at least).

Details:
- Adds the ability to specify the source interface of the broadcast instead of using the default or lowest metric interface. 
- Adds the ability to run on multiple interfaces, which is useful for running on a router or firewall (like the Unifi Dream Machine) to fix this for on multiple VLANs at once. For my use case, I needed a 2.4 GHz-only network for the printer (doesn't play nicely with band steering) and then needed to be able to send prints from my Wifi 7 network and my main hardwired VLAN. 
- Adds setting up a simple service to run the script on linux devices.

If you're not interested in this change, feel free to close the PR and I'll just use my fork for my own printer since I've been having trouble with the cloud connection. Thanks for putting this out in the first place. It helped me out!