### PR TITLE
feat: add printer name parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Specify the source address(es) as comma separated values. This will allow for br
 python3 bsnotify <printer-ip> <printer-serial-number> <local address(es)>
 ```
 
+By default, bsnotify generates the printer name from its serial number (`3DP-<SER>-<IAL>`).
+You can override this name with your own name:
+
+```
+python3 bsnotify <printer-ip> <printer-serial-number> <local address(es)> <printer-name>
+```
+
 ## The Details
 
 - Printer SSDP server does not seem to respond to SEARCH requests in any format.

--- a/bsnotify
+++ b/bsnotify
@@ -56,11 +56,18 @@ def setup():
                         "\n10.1.1.1,10.2.1.1",
                         default=None, 
                         nargs='?')
+    parser.add_argument("PRINTER_NAME",
+                        help="Override generated 3DP-SER-IAL printer name with custom value",
+                        default=None,
+                        nargs="?")
     args = parser.parse_args()
     CFG.PRINTER_IP = args.PRINTER_IP
     CFG.PRINTER_SN = args.PRINTER_SN
-    CFG.PRINTER_NAME = "3DP-{}-{}".format(CFG.PRINTER_SN[0:3],
-                                          CFG.PRINTER_SN[-3:])
+    if args.PRINTER_NAME is not None:
+        CFG.PRINTER_NAME = args.PRINTER_NAME
+    else:
+        CFG.PRINTER_NAME = "3DP-{}-{}".format(CFG.PRINTER_SN[0:3],
+                                              CFG.PRINTER_SN[-3:])
     CFG.LOCAL_ADDRESSES = args.LOCAL_ADDRESSES.split(",") if args.LOCAL_ADDRESSES else [None]
     return args
 


### PR DESCRIPTION
This PR adds an additional parameter that allows overriding the printer's name.

The feature is non-breaking, the previous invocation with 2 or 3 args still works.

Before (screenshot from OrcaSlicer):
![image](https://github.com/user-attachments/assets/20eb4d8b-28b7-494b-a254-6994cb086e04)

After:
![image](https://github.com/user-attachments/assets/6b03bbee-19e8-4685-8e13-23f95ae8c72c)

